### PR TITLE
Improve pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,12 +6,9 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
 
-  - repo: https://github.com/psf/black
-    rev: 24.1.1
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.4
     hooks:
-      - id: black
-
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
-    hooks:
-      - id: isort
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,21 @@ freezegun = "^1.2.2"
 coverage = "^7.1.0"
 requests-mock = "^1.10.0"
 
-[tool.isort]
-profile = "black"
+[tool.ruff.lint]
+select = [
+    # pycodestyle
+    "E",
+    # Pyflakes
+    "F",
+    # pyupgrade
+    "UP",
+    # flake8-bugbear
+    "B",
+    # flake8-simplify
+    "SIM",
+    # isort
+    "I",
+]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/src/churchsuite/__init__.py
+++ b/src/churchsuite/__init__.py
@@ -15,18 +15,18 @@ class Account:
 
     @property
     def base_url(self):
-        return "https://{churchsuite_account_id}.{domain}".format(
-            churchsuite_account_id=self.account_id, domain=CHURCHSUITE_BASE_DOMAIN
-        )
+        return f"https://{self.account_id}.{CHURCHSUITE_BASE_DOMAIN}"
 
     @property
     def calendar_json_url(self):
-        return "{base_url}/embed/calendar/json".format(base_url=self.base_url)
+        return f"{self.base_url}/embed/calendar/json"
 
-    def get_public_events_response(self, params={}):
+    def get_public_events_response(self, params=None):
+        if not params:
+            params = {}
         response = requests.get(url=self.calendar_json_url, params=params)
         return response.json()
 
-    def get_public_events(self, params={}):
+    def get_public_events(self, params=None):
         response = self.get_public_events_response(params)
         return map(lambda e: events.Event(e, self.account_timezone), response)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -1,9 +1,8 @@
 import json
 from pathlib import Path
 
-import requests_mock
-
 import churchsuite
+import requests_mock
 
 
 def test_base_url():

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from pathlib import Path
 
 import pytz
-
 from churchsuite import events
 
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -34,7 +34,7 @@ def test_naive_datetime_start():
 def test_localised_datetime_start_has_timezone():
     event = event_factory()
 
-    assert event.localised_datetime_start.tzinfo != None
+    assert event.localised_datetime_start.tzinfo is not None
 
 
 def test_localised_datetime_start_is_correct():


### PR DESCRIPTION
Swap out black and isort in favour of ruff and ruff-format, which are faster, more flexible and more configurable.

Where necessary, make code modifications to appease the more rigorous ruff code quality rules.